### PR TITLE
API response body evaluation

### DIFF
--- a/server/bank-accounts/src/main/java/com/pissouri/controller/ErrorAdvice.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/controller/ErrorAdvice.java
@@ -22,7 +22,7 @@ public class ErrorAdvice {
 
         return new ResponseDto<>()
                 .setStatusCode(ResponseStatusCode.SERVER_ERROR)
-                .setStatusText("Kaboom");
+                .setStatusText("Boom");
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)

--- a/server/bank-accounts/src/test/java/com/pissouri/JsonMatcher.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/JsonMatcher.java
@@ -1,0 +1,53 @@
+package com.pissouri;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+import org.skyscreamer.jsonassert.comparator.JSONComparator;
+
+/**
+ * A Hamcrest matcher for JSON content, using {@link JSONAssert}
+ */
+public final class JsonMatcher extends BaseMatcher<String> {
+
+    private String expected;
+    private JSONComparator comparator; // could be passed as a parameter, if needed
+
+    public JsonMatcher(String expected) {
+
+        this.expected = expected;
+        this.comparator = new CustomComparator(JSONCompareMode.STRICT);
+    }
+
+    @Override
+    public boolean matches(Object item) {
+
+        if (item instanceof String) {
+            try {
+                String actual = (String) item;
+                JSONAssert.assertEquals(expected, actual, comparator);
+
+            } catch (JSONException e) {
+                throw new AssertionError(e);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+
+        description.appendText(expected);
+    }
+
+    public static JsonMatcher equalToJson(String expected) {
+
+        return new JsonMatcher(expected);
+    }
+}

--- a/server/bank-accounts/src/test/java/com/pissouri/Resources.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/Resources.java
@@ -1,0 +1,44 @@
+package com.pissouri;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.NoSuchElementException;
+import java.util.Scanner;
+
+/**
+ * Static utility methods for managing resources
+ */
+final class Resources {
+
+    /**
+     * @return The contents of a class path resource file, by file name
+     */
+    static String getResourceAsString(String fileName, Class<?> callerClass) {
+
+        try (InputStream stream = getResourceAsStream(fileName, callerClass)) {
+            Scanner scanner = new Scanner(stream).useDelimiter("\\A");
+            return scanner.next();
+
+        } catch (NoSuchElementException e) {
+            return null;
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @return An input stream for a class path resource file, by file name
+     * @throws IOException If the resource could not be found
+     */
+    static InputStream getResourceAsStream(String fileName, Class<?> callerClass) throws IOException {
+
+        InputStream stream = callerClass.getResourceAsStream(fileName);
+        if (stream == null) {
+            String packageName = callerClass.getPackage().getName();
+            throw new IOException(String.format("File %s not found in package %s", fileName, packageName));
+        }
+
+        return stream;
+    }
+}

--- a/server/bank-accounts/src/test/java/com/pissouri/RestApiTest.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/RestApiTest.java
@@ -19,4 +19,14 @@ abstract public class RestApiTest {
         RestAssured.port = serverPort;
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
+
+    /**
+     * Read the contents of a resource file that should exist on the class path
+     * @param fileName The name of the file
+     * @return The contents of the file, null if file is empty
+     */
+    protected String readFromClasspath(String fileName) {
+
+        return Resources.getResourceAsString(fileName, getClass());
+    }
 }

--- a/server/bank-accounts/src/test/java/com/pissouri/controller/AccountControllerApiTest.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/controller/AccountControllerApiTest.java
@@ -7,8 +7,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static com.pissouri.JsonMatcher.equalToJson;
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.equalTo;
 
 @ApiTest
 @RunWith(SpringRunner.class)
@@ -17,6 +17,8 @@ public class AccountControllerApiTest extends RestApiTest {
     @Test
     public void getAccount_shouldReturnAccountDto() {
 
+        String expectedBody = readFromClasspath("getAccount_shouldReturnAccountDto.json");
+
         given()
                 .when()
                 .get("/account")
@@ -24,32 +26,6 @@ public class AccountControllerApiTest extends RestApiTest {
                 .assertThat()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .body("status_code", equalTo(2000))
-                .body("status_text", equalTo("ok"))
-                .body("data.id", equalTo(1))
-                .body("data.number", equalTo("PB100042"))
-                .body("data.currency", equalTo("EUR"))
-                .body("data.balance", equalTo(32750))
-                .body("data.reference", equalTo("4d2e6b5b-e1db-4227-b117-c3644b4f31a6"))
-                .body("data.registration.first_name", equalTo("John"))
-                .body("data.registration.last_name", equalTo("Cash"))
-                .body("data.registration.dob", equalTo("1985-10-25"))
-                .body("data.registration.nationality", equalTo("GB"))
-                .body("data.registration.address.street", equalTo("1 God Save the Queen Ave"))
-                .body("data.registration.address.city", equalTo("London"))
-                .body("data.registration.address.postal_code", equalTo("EC2700"))
-                .body("data.registration.address.country", equalTo("UK"))
-                .body("data.bank_route.full_name", equalTo("Cash, John"))
-                .body("data.bank_route.iban", equalTo("PB63910000004543"))
-                .body("data.bank_route.bic", equalTo("PBBE10080"))
-                .body("data.bank_route.swift_code", equalTo("PB10080"))
-                .body("data.bank_route.account_number", equalTo("90001050"))
-                .body("data.bank_route.sort_code", equalTo("100090"))
-                .body("data.bank_route.address.street", equalTo("1 King Ave"))
-                .body("data.bank_route.address.city", equalTo("Paphos"))
-                .body("data.bank_route.address.postal_code", equalTo("5200"))
-                .body("data.bank_route.address.country", equalTo("CY"))
-                .body("data.created_at", equalTo("2018-07-01T00:00:00+03:00"))
-                .body("data.updated_at", equalTo("2018-07-01T00:00:00+03:00"));
+                .body(equalToJson(expectedBody));
     }
 }

--- a/server/bank-accounts/src/test/java/com/pissouri/controller/ErrorAdviceApiTest.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/controller/ErrorAdviceApiTest.java
@@ -25,7 +25,7 @@ public class ErrorAdviceApiTest extends RestApiTest {
     @Test
     public void shouldReturnInternalServerErrorWithResponseDto_whenUnhandledExceptionThrown() {
 
-        when(accountService.getAccount(anyLong())).thenThrow(new RuntimeException("Ah shit"));
+        when(accountService.getAccount(anyLong())).thenThrow(new RuntimeException());
 
         given()
                 .when()
@@ -35,7 +35,7 @@ public class ErrorAdviceApiTest extends RestApiTest {
                 .statusCode(500)
                 .contentType(ContentType.JSON)
                 .body("status_code", equalTo(5000))
-                .body("status_text", equalTo("Kaboom"))
+                .body("status_text", equalTo("Boom"))
                 .body("data", nullValue());
     }
 }

--- a/server/bank-accounts/src/test/java/com/pissouri/controller/TransferControllerApiTest.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/controller/TransferControllerApiTest.java
@@ -7,9 +7,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static com.pissouri.dto.TransferStatusCode.ACCEPTED;
+import static com.pissouri.JsonMatcher.equalToJson;
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 @ApiTest
 @RunWith(SpringRunner.class)
@@ -20,6 +21,8 @@ public class TransferControllerApiTest extends RestApiTest {
 
         long transferId = 1L;
 
+        String expectedResponseBody = readFromClasspath("getAccountTransferById_shouldReturnTransferDto_whenTransferFound.json");
+
         given()
                 .when()
                 .get(String.format("/account/transfers/%s", transferId))
@@ -27,27 +30,22 @@ public class TransferControllerApiTest extends RestApiTest {
                 .assertThat()
                 .statusCode(200)
                 .contentType(ContentType.JSON)
-                .body("data.id", equalTo(1))
-                .body("data.amount", equalTo(-2750))
-                .body("data.currency", equalTo("EUR"))
-                .body("data.status", equalTo(ACCEPTED))
-                .body("data.balance_after", equalTo(18500))
-                .body("data.reference", equalTo("eec6671b-c0d4-4833-9779-f4cbdb117eb7"))
-                .body("data.created_at", equalTo("2018-07-01T00:00:00+03:00"))
-                .body("data.originator", nullValue())
-                .body("data.beneficiary", notNullValue())
-                .body("data.beneficiary.full_name", equalTo("TERRA NOVA Ltd"))
-                .body("data.beneficiary.bic", equalTo("CYBE17580"))
-                .body("data.beneficiary.iban", equalTo("CY75910000004587"))
-                .body("data.beneficiary.swift_code", nullValue())
-                .body("data.beneficiary.account_number", nullValue())
-                .body("data.beneficiary.sort_code", nullValue())
-                .body("data.beneficiary.address", notNullValue())
-                .body("data.beneficiary.address.street", equalTo("5 MAKARIOU Ave"))
-                .body("data.beneficiary.address.city", equalTo("Nicosia"))
-                .body("data.beneficiary.address.state", nullValue())
-                .body("data.beneficiary.address.postal_code", equalTo("2200"))
-                .body("data.beneficiary.address.country", equalTo("CY"));
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfTransferDto() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_shouldReturnListOfTransferDto.json");
+
+        given()
+                .when()
+                .get("/account/transfers")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
     }
 
     @Test
@@ -81,42 +79,5 @@ public class TransferControllerApiTest extends RestApiTest {
                 .body("status_code", equalTo(4000))
                 .body("status_text", equalTo("Invalid argument -1"))
                 .body("data", nullValue());
-    }
-
-    @Test
-    public void getAccountTransfers_shouldReturnListOfTransferDto() {
-
-        given()
-                .when()
-                .get("/account/transfers")
-                .then()
-                .assertThat()
-                .statusCode(200)
-                .contentType(ContentType.JSON)
-                .body("status_code", equalTo(2000))
-                .body("status_text", equalTo("ok"))
-                .body("data", notNullValue())
-
-                .body("data[0].id", equalTo(1))
-                .body("data[0].amount", equalTo(-2750))
-                .body("data[0].currency", equalTo("EUR"))
-                .body("data[0].status", equalTo(ACCEPTED))
-                .body("data[0].balance_after", equalTo(18500))
-                .body("data[0].reference", equalTo("eec6671b-c0d4-4833-9779-f4cbdb117eb7"))
-                .body("data[0].created_at", equalTo("2018-07-01T00:00:00+03:00"))
-                .body("data[0].originator", nullValue())
-                .body("data[0].beneficiary", notNullValue())
-                .body("data[0].beneficiary.full_name", equalTo("TERRA NOVA Ltd"))
-                .body("data[0].beneficiary.bic", equalTo("CYBE17580"))
-                .body("data[0].beneficiary.iban", equalTo("CY75910000004587"))
-                .body("data[0].beneficiary.swift_code", nullValue())
-                .body("data[0].beneficiary.account_number", nullValue())
-                .body("data[0].beneficiary.sort_code", nullValue())
-                .body("data[0].beneficiary.address", notNullValue())
-                .body("data[0].beneficiary.address.street", equalTo("5 MAKARIOU Ave"))
-                .body("data[0].beneficiary.address.city", equalTo("Nicosia"))
-                .body("data[0].beneficiary.address.state", nullValue())
-                .body("data[0].beneficiary.address.postal_code", equalTo("2200"))
-                .body("data[0].beneficiary.address.country", equalTo("CY"));
     }
 }

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransferById_shouldReturnTransferDto_whenTransferFound.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransferById_shouldReturnTransferDto_whenTransferFound.json
@@ -1,0 +1,29 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": {
+    "id": 1,
+    "amount": -2750,
+    "currency": "EUR",
+    "status": "ACCEPTED",
+    "originator": null,
+    "beneficiary": {
+      "full_name": "TERRA NOVA Ltd",
+      "iban": "CY75910000004587",
+      "bic": "CYBE17580",
+      "swift_code": null,
+      "account_number": null,
+      "sort_code": null,
+      "address": {
+        "street": "5 MAKARIOU Ave",
+        "city": "Nicosia",
+        "state": null,
+        "postal_code": "2200",
+        "country": "CY"
+      }
+    },
+    "balance_after": 18500,
+    "reference": "eec6671b-c0d4-4833-9779-f4cbdb117eb7",
+    "created_at": "2018-07-01T00:00:00+03:00"
+  }
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_shouldReturnListOfTransferDto.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_shouldReturnListOfTransferDto.json
@@ -1,0 +1,256 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 1,
+      "amount": -2750,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 18500,
+      "reference": "eec6671b-c0d4-4833-9779-f4cbdb117eb7",
+      "created_at": "2018-07-01T00:00:00+03:00"
+    },
+    {
+      "id": 2,
+      "amount": -3875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 16500,
+      "reference": "0d0173d9-898b-4e2f-a762-2af6bbc461eb",
+      "created_at": "2018-07-02T00:00:00+03:00"
+    },
+    {
+      "id": 3,
+      "amount": -1820,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 11500,
+      "reference": "55bae2c9-92d0-4fdf-9283-e7ff088bc554",
+      "created_at": "2018-07-03T00:00:00+03:00"
+    },
+    {
+      "id": 4,
+      "amount": 12500,
+      "currency": "GBP",
+      "status": "ACCEPTED",
+      "originator": {
+        "full_name": "TransferWise Ltd",
+        "iban": "GB75828000008310",
+        "bic": "GB8011287",
+        "swift_code": null,
+        "account_number": "92501054",
+        "sort_code": "100091",
+        "address": {
+          "street": "28 United City Str",
+          "city": "Manchester",
+          "state": null,
+          "postal_code": "EC7255",
+          "country": "UK"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 11500,
+      "reference": "a482ef89-7d05-4610-98fb-26a86dfbc818",
+      "created_at": "2018-07-04T00:00:00+03:00"
+    },
+    {
+      "id": 5,
+      "amount": 37500,
+      "currency": "GBP",
+      "status": "PENDING",
+      "originator": {
+        "full_name": "TransferWise Ltd",
+        "iban": "GB75828000008310",
+        "bic": "GB8011287",
+        "swift_code": null,
+        "account_number": "92501054",
+        "sort_code": "100091",
+        "address": {
+          "street": "28 United City Str",
+          "city": "Manchester",
+          "state": null,
+          "postal_code": "EC7255",
+          "country": "UK"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 11500,
+      "reference": "3e52d8ba-04ff-41ea-aa80-59dd0485fb60",
+      "created_at": "2018-07-05T00:00:00+03:00"
+    },
+    {
+      "id": 6,
+      "amount": -500,
+      "currency": "AUD",
+      "status": "PENDING",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "Jack Rabbit",
+        "iban": "AU63910000004543",
+        "bic": null,
+        "swift_code": "AU9004559087",
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "13 Music and Coffee Str",
+          "city": "Melbourne",
+          "state": null,
+          "postal_code": "ML5211",
+          "country": "AU"
+        }
+      },
+      "balance_after": 11000,
+      "reference": "04582a1c-6e5e-4e3e-867c-5a34a02e25c4",
+      "created_at": "2018-07-06T00:00:00+03:00"
+    },
+    {
+      "id": 7,
+      "amount": 77500,
+      "currency": "USD",
+      "status": "PENDING",
+      "originator": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 18500,
+      "reference": "?",
+      "created_at": "2018-07-07T00:00:00+03:00"
+    },
+    {
+      "id": 8,
+      "amount": 27500,
+      "currency": "USD",
+      "status": "REJECTED",
+      "originator": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 18500,
+      "reference": "9d25d635-783a-4b25-bb47-c434036deab6",
+      "created_at": "2018-07-08T00:00:00+03:00"
+    },
+    {
+      "id": 9,
+      "amount": -7550,
+      "currency": "USD",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "balance_after": 17250,
+      "reference": "f5eb8765-3545-48e3-9b73-89045ccdfd3e",
+      "created_at": "2018-07-09T00:00:00+03:00"
+    },
+    {
+      "id": 10,
+      "amount": -4875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "Quality Steaks Ltd",
+        "iban": "CY83910000007593",
+        "bic": "CYBE19280",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "7 Zenon Sqr",
+          "city": "Larnaca",
+          "state": null,
+          "postal_code": "4200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 13500,
+      "reference": "bd8ded75-bce2-45bc-8365-e42a8310223d",
+      "created_at": "2018-07-10T00:00:00+03:00"
+    }
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccount_shouldReturnAccountDto.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccount_shouldReturnAccountDto.json
@@ -1,0 +1,41 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": {
+    "id": 1,
+    "number": "PB100042",
+    "balance": 32750,
+    "currency": "EUR",
+    "reference": "4d2e6b5b-e1db-4227-b117-c3644b4f31a6",
+    "registration": {
+      "first_name": "John",
+      "last_name": "Cash",
+      "nationality": "GB",
+      "address": {
+        "street": "1 God Save the Queen Ave",
+        "city": "London",
+        "state": null,
+        "postal_code": "EC2700",
+        "country": "UK"
+      },
+      "dob": "1985-10-25"
+    },
+    "bank_route": {
+      "full_name": "Cash, John",
+      "iban": "PB63910000004543",
+      "bic": "PBBE10080",
+      "swift_code": "PB10080",
+      "account_number": "90001050",
+      "sort_code": "100090",
+      "address": {
+        "street": "1 King Ave",
+        "city": "Paphos",
+        "state": null,
+        "postal_code": "5200",
+        "country": "CY"
+      }
+    },
+    "created_at": "2018-07-01T00:00:00+03:00",
+    "updated_at": "2018-07-01T00:00:00+03:00"
+  }
+}


### PR DESCRIPTION
* Added custom Hamcrest JSON matcher (based on JSONAssert)
* Added utility methods for managing (just reading, for now) resource files
* Updated API testing base class so that it can now read resource files from class path
* Updated API tests so that they now attempt to match the response body with JSON resource files
* Indirectly introducing convention on JSON resource files: file name should match test method name
* Minor updates in error advice controller and associated tests