### PR TITLE
Transfers by search criteria [#3] and (minor) restructuring

### DIFF
--- a/server/bank-accounts/src/main/java/com/pissouri/common/TransferStatusCode.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/common/TransferStatusCode.java
@@ -1,4 +1,4 @@
-package com.pissouri.dto;
+package com.pissouri.common;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/server/bank-accounts/src/main/java/com/pissouri/common/TransferTypeCode.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/common/TransferTypeCode.java
@@ -1,4 +1,4 @@
-package com.pissouri.dto;
+package com.pissouri.common;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/server/bank-accounts/src/main/java/com/pissouri/data/Transfer.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/data/Transfer.java
@@ -1,6 +1,6 @@
 package com.pissouri.data;
 
-import com.pissouri.dto.TransferStatusCode;
+import com.pissouri.common.TransferStatusCode;
 
 import javax.persistence.*;
 import java.time.ZonedDateTime;

--- a/server/bank-accounts/src/main/java/com/pissouri/data/TransferRepository.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/data/TransferRepository.java
@@ -1,16 +1,13 @@
 package com.pissouri.data;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface TransferRepository extends JpaRepository<Transfer, Long> {
+public interface TransferRepository extends JpaRepository<Transfer, Long>, JpaSpecificationExecutor<Transfer> {
 
     Optional<Transfer> findByIdAndAccountId(Long id, Long accountId);
-
-    Page<Transfer> findAllByAccountId(Long accountId, Pageable pageable);
 }

--- a/server/bank-accounts/src/main/java/com/pissouri/data/TransferSpecification.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/data/TransferSpecification.java
@@ -1,0 +1,71 @@
+package com.pissouri.data;
+
+import com.pissouri.common.TransferStatusCode;
+import com.pissouri.common.TransferTypeCode;
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static com.pissouri.common.TransferTypeCode.INCOMING;
+import static com.pissouri.common.TransferTypeCode.OUTGOING;
+
+/**
+ * JPA specification for {@link Transfer} records
+ */
+public class TransferSpecification implements Specification<Transfer> {
+
+    /** The identifier of the {@link Account} the record should be associated with */
+    private Long accountId;
+
+    /** The status of a record, as per {@link TransferStatusCode} */
+    private String status;
+
+    /** The type of a record, as per {@link TransferTypeCode} */
+    private String type;
+
+    public TransferSpecification setAccountId(Long accountId) {
+
+        this.accountId = accountId;
+        return this;
+    }
+
+    public TransferSpecification setStatus(String status) {
+
+        this.status = status;
+        return this;
+    }
+
+    public TransferSpecification setType(String type) {
+
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * @return A {@link Predicate} composed of conditions based on the class fields
+     */
+    @Override
+    public Predicate toPredicate(Root<Transfer> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (Objects.nonNull(accountId)) {
+            Path<Account> account = root.get("account");
+            predicates.add(builder.equal(account.get("id"), accountId));
+        }
+
+        if (Objects.nonNull(status)) {
+            predicates.add(builder.equal(root.get("status"), status));
+        }
+
+        if (Objects.nonNull(type)) {
+            if (INCOMING.equals(type)) predicates.add(builder.greaterThan(root.get("amount"), 0));
+            if (OUTGOING.equals(type)) predicates.add(builder.lessThan(root.get("amount"), 0));
+        }
+
+        return builder.and(predicates.toArray(new Predicate[0]));
+    }
+}

--- a/server/bank-accounts/src/main/java/com/pissouri/dto/TransferDto.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/dto/TransferDto.java
@@ -1,5 +1,7 @@
 package com.pissouri.dto;
 
+import com.pissouri.common.TransferStatusCode;
+
 import java.time.ZonedDateTime;
 import java.util.Objects;
 

--- a/server/bank-accounts/src/main/java/com/pissouri/dto/TransferSearchDto.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/dto/TransferSearchDto.java
@@ -1,5 +1,8 @@
 package com.pissouri.dto;
 
+import com.pissouri.common.TransferStatusCode;
+import com.pissouri.common.TransferTypeCode;
+
 import java.util.Objects;
 
 /**

--- a/server/bank-accounts/src/main/java/com/pissouri/service/TransferService.java
+++ b/server/bank-accounts/src/main/java/com/pissouri/service/TransferService.java
@@ -1,6 +1,7 @@
 package com.pissouri.service;
 
 import com.pissouri.data.TransferRepository;
+import com.pissouri.data.TransferSpecification;
 import com.pissouri.dto.TransferDto;
 import com.pissouri.dto.TransferSearchDto;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,10 +42,15 @@ public class TransferService {
 
         Arguments.must(accountId, accountId > 0);
 
+        TransferSpecification specification = new TransferSpecification()
+                .setAccountId(accountId)
+                .setStatus(searchDto.getStatus())
+                .setType(searchDto.getType());
+
         Pageable pageable = Paging.of(searchDto, Sort.by("id").descending());
 
         return transferRepository
-                .findAllByAccountId(accountId, pageable)
+                .findAll(specification, pageable)
                 .stream()
                 .map(transfer -> conversionService.convert(transfer, TransferDto.class))
                 .collect(Collectors.toList());

--- a/server/bank-accounts/src/test/java/com/pissouri/controller/TransferControllerApiTest.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/controller/TransferControllerApiTest.java
@@ -49,6 +49,141 @@ public class TransferControllerApiTest extends RestApiTest {
     }
 
     @Test
+    public void getAccountTransfers_shouldReturnListOfINWARDTransferDto_whenTypeParameterIsINWARD() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenTypeParameterIsINWARD.json");
+
+        given()
+                .when()
+                .get("/account/transfers?type=IN")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfOUTWARDTransferDto_whenTypeParameterIsOUTWARD() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenTypeParameterIsOUTWARD.json");
+
+        given()
+                .when()
+                .get("/account/transfers?type=OUT")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfTransferDto_whenTypeParameterIsInvalid() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenTransfersFound.json");
+
+        given()
+                .when()
+                .get("/account/transfers?type=FOOBAR")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfACCEPTEDTransferDto_whenStatusParameterIsACCEPTED() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenStatusParameterIsACCEPTED.json");
+
+        given()
+                .when()
+                .get("/account/transfers?status=ACCEPTED")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfPENDINGTransferDto_whenStatusParameterIsPENDING() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenStatusParameterIsPENDING.json");
+
+        given()
+                .when()
+                .get("/account/transfers?status=PENDING")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfREJECTEDTransferDto_whenStatusParameterIsREJECTED() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenStatusParameterIsREJECTED.json");
+
+        given()
+                .when()
+                .get("/account/transfers?status=REJECTED")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnEmptyListOfTransferDto_whenStatusParameterIsInvalid() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenStatusParameterIsInvalid.json");
+
+        given()
+                .when()
+                .get("/account/transfers?status=FOOBAR")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfTransferDto_whenStatusAndTypeParametersProvided() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenStatusAndTypeParametersProvided.json");
+
+        given()
+                .when()
+                .get("/account/transfers?type=OUT&status=ACCEPTED")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnEmptyListOfTransferDto_whenTypeParameterIsValidAndStatusParameterIsInvalid() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenStatusParameterIsInvalid.json");
+
+        given()
+                .when()
+                .get("/account/transfers?type=OUT&status=FOOBAR")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
+    }
+
+    @Test
     public void getAccountTransfers_shouldReturnPartOfListOfTransferDto_whenSizeParameterIsProvided() {
 
         String expectedResponseBody = readFromClasspath("getAccountTransfers_whenPageParameterIsProvided.json");
@@ -121,6 +256,21 @@ public class TransferControllerApiTest extends RestApiTest {
                 .body("status_code", equalTo(4000))
                 .body("status_text", equalTo("Page index must not be less than zero!"))
                 .body("data", nullValue());
+    }
+
+    @Test
+    public void getAccountTransfers_shouldReturnListOfTransferDto_whenStatusAndTypeAndPageAndSizeProvided() {
+
+        String expectedResponseBody = readFromClasspath("getAccountTransfers_whenStatusAndTypeAndPageAndSizeProvided.json");
+
+        given()
+                .when()
+                .get("/account/transfers?type=OUT&status=ACCEPTED&page=1&size=1")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .body(equalToJson(expectedResponseBody));
     }
 
     @Test

--- a/server/bank-accounts/src/test/java/com/pissouri/service/TransferServiceUTest.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/service/TransferServiceUTest.java
@@ -6,6 +6,7 @@ import com.pissouri.converter.TransferDtoConverter;
 import com.pissouri.data.BankRoute;
 import com.pissouri.data.Transfer;
 import com.pissouri.data.TransferRepository;
+import com.pissouri.data.TransferSpecification;
 import com.pissouri.dto.TransferDto;
 import com.pissouri.dto.TransferSearchDto;
 import org.junit.Before;
@@ -146,7 +147,7 @@ public class TransferServiceUTest {
     private void givenTransfers() {
 
         Mockito
-                .when(transferRepository.findAllByAccountId(eq(1L), any(Pageable.class)))
+                .when(transferRepository.findAll(any(TransferSpecification.class), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(Arrays.asList(
                         new Transfer()
                                 .setId(1L)

--- a/server/bank-accounts/src/test/java/com/pissouri/service/TransferServiceUTest.java
+++ b/server/bank-accounts/src/test/java/com/pissouri/service/TransferServiceUTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static com.pissouri.dto.TransferStatusCode.*;
+import static com.pissouri.common.TransferStatusCode.*;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusAndTypeAndPageAndSizeProvided.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusAndTypeAndPageAndSizeProvided.json
@@ -1,0 +1,31 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 9,
+      "amount": -7550,
+      "currency": "USD",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "balance_after": 17250,
+      "reference": "f5eb8765-3545-48e3-9b73-89045ccdfd3e",
+      "created_at": "2018-07-09T00:00:00+03:00"
+    }
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusAndTypeParametersProvided.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusAndTypeParametersProvided.json
@@ -1,0 +1,131 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 10,
+      "amount": -4875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "Quality Steaks Ltd",
+        "iban": "CY83910000007593",
+        "bic": "CYBE19280",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "7 Zenon Sqr",
+          "city": "Larnaca",
+          "state": null,
+          "postal_code": "4200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 13500,
+      "reference": "bd8ded75-bce2-45bc-8365-e42a8310223d",
+      "created_at": "2018-07-10T00:00:00+03:00"
+    },
+    {
+      "id": 9,
+      "amount": -7550,
+      "currency": "USD",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "balance_after": 17250,
+      "reference": "f5eb8765-3545-48e3-9b73-89045ccdfd3e",
+      "created_at": "2018-07-09T00:00:00+03:00"
+    },
+    {
+      "id": 3,
+      "amount": -1820,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 11500,
+      "reference": "55bae2c9-92d0-4fdf-9283-e7ff088bc554",
+      "created_at": "2018-07-03T00:00:00+03:00"
+    },
+    {
+      "id": 2,
+      "amount": -3875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 16500,
+      "reference": "0d0173d9-898b-4e2f-a762-2af6bbc461eb",
+      "created_at": "2018-07-02T00:00:00+03:00"
+    },
+    {
+      "id": 1,
+      "amount": -2750,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 18500,
+      "reference": "eec6671b-c0d4-4833-9779-f4cbdb117eb7",
+      "created_at": "2018-07-01T00:00:00+03:00"
+    }
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsACCEPTED.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsACCEPTED.json
@@ -1,0 +1,156 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 10,
+      "amount": -4875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "Quality Steaks Ltd",
+        "iban": "CY83910000007593",
+        "bic": "CYBE19280",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "7 Zenon Sqr",
+          "city": "Larnaca",
+          "state": null,
+          "postal_code": "4200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 13500,
+      "reference": "bd8ded75-bce2-45bc-8365-e42a8310223d",
+      "created_at": "2018-07-10T00:00:00+03:00"
+    },
+    {
+      "id": 9,
+      "amount": -7550,
+      "currency": "USD",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "balance_after": 17250,
+      "reference": "f5eb8765-3545-48e3-9b73-89045ccdfd3e",
+      "created_at": "2018-07-09T00:00:00+03:00"
+    },
+    {
+      "id": 4,
+      "amount": 12500,
+      "currency": "GBP",
+      "status": "ACCEPTED",
+      "originator": {
+        "full_name": "TransferWise Ltd",
+        "iban": "GB75828000008310",
+        "bic": "GB8011287",
+        "swift_code": null,
+        "account_number": "92501054",
+        "sort_code": "100091",
+        "address": {
+          "street": "28 United City Str",
+          "city": "Manchester",
+          "state": null,
+          "postal_code": "EC7255",
+          "country": "UK"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 11500,
+      "reference": "a482ef89-7d05-4610-98fb-26a86dfbc818",
+      "created_at": "2018-07-04T00:00:00+03:00"
+    },
+    {
+      "id": 3,
+      "amount": -1820,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 11500,
+      "reference": "55bae2c9-92d0-4fdf-9283-e7ff088bc554",
+      "created_at": "2018-07-03T00:00:00+03:00"
+    },
+    {
+      "id": 2,
+      "amount": -3875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 16500,
+      "reference": "0d0173d9-898b-4e2f-a762-2af6bbc461eb",
+      "created_at": "2018-07-02T00:00:00+03:00"
+    },
+    {
+      "id": 1,
+      "amount": -2750,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 18500,
+      "reference": "eec6671b-c0d4-4833-9779-f4cbdb117eb7",
+      "created_at": "2018-07-01T00:00:00+03:00"
+    }
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsInvalid.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsInvalid.json
@@ -1,0 +1,7 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsPENDING.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsPENDING.json
@@ -1,0 +1,81 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 7,
+      "amount": 77500,
+      "currency": "USD",
+      "status": "PENDING",
+      "originator": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 18500,
+      "reference": "?",
+      "created_at": "2018-07-07T00:00:00+03:00"
+    },
+    {
+      "id": 6,
+      "amount": -500,
+      "currency": "AUD",
+      "status": "PENDING",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "Jack Rabbit",
+        "iban": "AU63910000004543",
+        "bic": null,
+        "swift_code": "AU9004559087",
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "13 Music and Coffee Str",
+          "city": "Melbourne",
+          "state": null,
+          "postal_code": "ML5211",
+          "country": "AU"
+        }
+      },
+      "balance_after": 11000,
+      "reference": "04582a1c-6e5e-4e3e-867c-5a34a02e25c4",
+      "created_at": "2018-07-06T00:00:00+03:00"
+    },
+    {
+      "id": 5,
+      "amount": 37500,
+      "currency": "GBP",
+      "status": "PENDING",
+      "originator": {
+        "full_name": "TransferWise Ltd",
+        "iban": "GB75828000008310",
+        "bic": "GB8011287",
+        "swift_code": null,
+        "account_number": "92501054",
+        "sort_code": "100091",
+        "address": {
+          "street": "28 United City Str",
+          "city": "Manchester",
+          "state": null,
+          "postal_code": "EC7255",
+          "country": "UK"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 11500,
+      "reference": "3e52d8ba-04ff-41ea-aa80-59dd0485fb60",
+      "created_at": "2018-07-05T00:00:00+03:00"
+    }
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsREJECTED.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenStatusParameterIsREJECTED.json
@@ -1,0 +1,31 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 8,
+      "amount": 27500,
+      "currency": "USD",
+      "status": "REJECTED",
+      "originator": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 18500,
+      "reference": "9d25d635-783a-4b25-bb47-c434036deab6",
+      "created_at": "2018-07-08T00:00:00+03:00"
+    }
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenTypeParameterIsINWARD.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenTypeParameterIsINWARD.json
@@ -1,0 +1,106 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 8,
+      "amount": 27500,
+      "currency": "USD",
+      "status": "REJECTED",
+      "originator": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 18500,
+      "reference": "9d25d635-783a-4b25-bb47-c434036deab6",
+      "created_at": "2018-07-08T00:00:00+03:00"
+    },
+    {
+      "id": 7,
+      "amount": 77500,
+      "currency": "USD",
+      "status": "PENDING",
+      "originator": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 18500,
+      "reference": "?",
+      "created_at": "2018-07-07T00:00:00+03:00"
+    },
+    {
+      "id": 5,
+      "amount": 37500,
+      "currency": "GBP",
+      "status": "PENDING",
+      "originator": {
+        "full_name": "TransferWise Ltd",
+        "iban": "GB75828000008310",
+        "bic": "GB8011287",
+        "swift_code": null,
+        "account_number": "92501054",
+        "sort_code": "100091",
+        "address": {
+          "street": "28 United City Str",
+          "city": "Manchester",
+          "state": null,
+          "postal_code": "EC7255",
+          "country": "UK"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 11500,
+      "reference": "3e52d8ba-04ff-41ea-aa80-59dd0485fb60",
+      "created_at": "2018-07-05T00:00:00+03:00"
+    },
+    {
+      "id": 4,
+      "amount": 12500,
+      "currency": "GBP",
+      "status": "ACCEPTED",
+      "originator": {
+        "full_name": "TransferWise Ltd",
+        "iban": "GB75828000008310",
+        "bic": "GB8011287",
+        "swift_code": null,
+        "account_number": "92501054",
+        "sort_code": "100091",
+        "address": {
+          "street": "28 United City Str",
+          "city": "Manchester",
+          "state": null,
+          "postal_code": "EC7255",
+          "country": "UK"
+        }
+      },
+      "beneficiary": null,
+      "balance_after": 11500,
+      "reference": "a482ef89-7d05-4610-98fb-26a86dfbc818",
+      "created_at": "2018-07-04T00:00:00+03:00"
+    }
+  ]
+}

--- a/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenTypeParameterIsOUTWARD.json
+++ b/server/bank-accounts/src/test/resources/com/pissouri/controller/getAccountTransfers_whenTypeParameterIsOUTWARD.json
@@ -1,0 +1,156 @@
+{
+  "status_code": 2000,
+  "status_text": "ok",
+  "data": [
+    {
+      "id": 10,
+      "amount": -4875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "Quality Steaks Ltd",
+        "iban": "CY83910000007593",
+        "bic": "CYBE19280",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "7 Zenon Sqr",
+          "city": "Larnaca",
+          "state": null,
+          "postal_code": "4200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 13500,
+      "reference": "bd8ded75-bce2-45bc-8365-e42a8310223d",
+      "created_at": "2018-07-10T00:00:00+03:00"
+    },
+    {
+      "id": 9,
+      "amount": -7550,
+      "currency": "USD",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "PayPal US Inc.",
+        "iban": "US95910000874090",
+        "bic": "US9010095",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "1 Times Square Ave",
+          "city": "NYC",
+          "state": null,
+          "postal_code": "7500",
+          "country": "US"
+        }
+      },
+      "balance_after": 17250,
+      "reference": "f5eb8765-3545-48e3-9b73-89045ccdfd3e",
+      "created_at": "2018-07-09T00:00:00+03:00"
+    },
+    {
+      "id": 6,
+      "amount": -500,
+      "currency": "AUD",
+      "status": "PENDING",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "Jack Rabbit",
+        "iban": "AU63910000004543",
+        "bic": null,
+        "swift_code": "AU9004559087",
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "13 Music and Coffee Str",
+          "city": "Melbourne",
+          "state": null,
+          "postal_code": "ML5211",
+          "country": "AU"
+        }
+      },
+      "balance_after": 11000,
+      "reference": "04582a1c-6e5e-4e3e-867c-5a34a02e25c4",
+      "created_at": "2018-07-06T00:00:00+03:00"
+    },
+    {
+      "id": 3,
+      "amount": -1820,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 11500,
+      "reference": "55bae2c9-92d0-4fdf-9283-e7ff088bc554",
+      "created_at": "2018-07-03T00:00:00+03:00"
+    },
+    {
+      "id": 2,
+      "amount": -3875,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 16500,
+      "reference": "0d0173d9-898b-4e2f-a762-2af6bbc461eb",
+      "created_at": "2018-07-02T00:00:00+03:00"
+    },
+    {
+      "id": 1,
+      "amount": -2750,
+      "currency": "EUR",
+      "status": "ACCEPTED",
+      "originator": null,
+      "beneficiary": {
+        "full_name": "TERRA NOVA Ltd",
+        "iban": "CY75910000004587",
+        "bic": "CYBE17580",
+        "swift_code": null,
+        "account_number": null,
+        "sort_code": null,
+        "address": {
+          "street": "5 MAKARIOU Ave",
+          "city": "Nicosia",
+          "state": null,
+          "postal_code": "2200",
+          "country": "CY"
+        }
+      },
+      "balance_after": 18500,
+      "reference": "eec6671b-c0d4-4833-9779-f4cbdb117eb7",
+      "created_at": "2018-07-01T00:00:00+03:00"
+    }
+  ]
+}


### PR DESCRIPTION
#3 Transfers by search criteria
* Transfer repository as a JPA Specification Executor
* Transfer JPA specification based on Transfer Search DTO criteria
* Transfer service converts search DTO and queries by specification
* Associated integration (Api) tests
* Updated Transfer Repository mocks in unit tests accordingly

Common is as common is used
* Moved transfer status and type code definitions from dto to common
* Updated references and Javadoc accordingly